### PR TITLE
Exposed SDL functions for dealing with time 

### DIFF
--- a/SDL-Sharp/SDL/SDL.Audio.cs
+++ b/SDL-Sharp/SDL/SDL.Audio.cs
@@ -221,6 +221,15 @@ public static unsafe partial class SDL
     [DllImport(LibraryName, EntryPoint = "SDL_GetTicks", CallingConvention = CallingConvention.Cdecl)]
     public static extern uint GetTicks();
 
+    [DllImport(LibraryName, EntryPoint = "SDL_GetTicks64", CallingConvention = CallingConvention.Cdecl)]
+    public static extern ulong GetTicks64();
+
+    [DllImport(LibraryName, EntryPoint = "SDL_GetPerformanceCounter", CallingConvention = CallingConvention.Cdecl)]
+    public static extern ulong GetPerformanceCounter();
+
+    [DllImport(LibraryName, EntryPoint = "SDL_GetPerformanceFrequency", CallingConvention = CallingConvention.Cdecl)]
+    public static extern ulong GetPerformanceFrequency();
+
     [DllImport(LibraryName, EntryPoint = "SDL_memcpy", SetLastError = true)]
     public static extern void* MemCopy(IntPtr dst, IntPtr src, int len);
 

--- a/SDL-Sharp/SDL/SDL.Video.cs
+++ b/SDL-Sharp/SDL/SDL.Video.cs
@@ -330,10 +330,10 @@ public static unsafe partial class SDL
     [DllImport(LibraryName, EntryPoint = "SDL_SetWindowBrightness", CallingConvention = CallingConvention.Cdecl)]
     public static extern int SetWindowBrightness(Window window, float brightness);
 
-    [DllImport(LibraryName, EntryPoint = "SDL_SetWindowIcon", CallingConvention = CallingConvention.Cdecl]
+    [DllImport(LibraryName, EntryPoint = "SDL_SetWindowIcon", CallingConvention = CallingConvention.Cdecl)]
     public static extern void SetWindowIcon(Window window, Surface* icon);
 
-    [DllImport(LibraryName, EntryPoint = "SDL_SetWindowIcon", CallingConvention = CallingConvention.Cdecl]
+    [DllImport(LibraryName, EntryPoint = "SDL_SetWindowIcon", CallingConvention = CallingConvention.Cdecl)]
     public static extern void SetWindowIcon(Window window, PSurface icon);
 
     [DllImport(LibraryName, EntryPoint = "SDL_SetWindowData", CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi, BestFitMapping = false, ThrowOnUnmappableChar = true)]


### PR DESCRIPTION
Exposed new methods in the SDL class for:
- SDL_GetTicks64
- SDL_GetPerformanceCounter
- SDL_GetPerformanceFrequency

These aren't essential, but they're core functionality in SDL; the existing `GetTicks` has documentation suggesting use of GetTicks64 instead. My motivation for adding the additional methods was an effort to convert https://github.com/zachbarth/minimalist-game-framework to .Net 8 and reliant on an existing SDL nuget package (the package built from this repository) rather than reimplementing all of the interop in the project.

As a side note, I noticed that `GetTicks` was implemented in `SDL.Audio.cs` which is probably not organizationally the right place for it -- but I just followed suit because I believe the new methods belong wherever `GetTicks` is.

I also made the same fix as a pending pull-request, but that change should disappear once it's approved.