### PR TITLE
Use .NET8 and enable AOT compatibility

### DIFF
--- a/Exemples/SDL_EXTENSIONS/Code/Program.cs
+++ b/Exemples/SDL_EXTENSIONS/Code/Program.cs
@@ -4,6 +4,7 @@ using SDL_Sharp.Mixer;
 using SDL_Sharp.Utility;
 using SDL_Sharp;
 using System;
+using SDL_EXTENSIONS.Utils;
 
 namespace SDL_PLUS_EXTENSIONS;
 class Program

--- a/Exemples/SDL_EXTENSIONS/SDL_EXTENSIONS.csproj
+++ b/Exemples/SDL_EXTENSIONS/SDL_EXTENSIONS.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Platforms>x64;AnyCPU;x86</Platforms>
     <ApplicationIcon />
     <StartupObject />
@@ -32,6 +32,10 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\SDL-Sharp\SDL-Sharp.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="protobuf-net" Version="3.2.30" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Exemples/SDL_EXTENSIONS/Utils/Utils.cs
+++ b/Exemples/SDL_EXTENSIONS/Utils/Utils.cs
@@ -1,12 +1,13 @@
 ﻿using System;
 using System.IO;
-using System.Xml;
-using System.Text.Json;
-using System.Xml.Serialization;
 using System.Runtime.InteropServices;
 using System.Security.Cryptography;
+using System.Text.Json;
+using System.Xml;
+using System.Xml.Serialization;
 
-namespace SDL_Sharp.Utility;
+namespace SDL_EXTENSIONS.Utils;
+
 public static class Utils
 {
     static readonly byte[] key =

--- a/Exemples/SDL_OPENGL/SDL_OPENGL.csproj
+++ b/Exemples/SDL_OPENGL/SDL_OPENGL.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Platforms>x64;AnyCPU;x86</Platforms>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/SDL-Sharp/SDL-Sharp.csproj
+++ b/SDL-Sharp/SDL-Sharp.csproj
@@ -5,6 +5,8 @@
     <RootNamespace>SDL_Sharp</RootNamespace>
     <Platforms>x64;AnyCPU;x86</Platforms>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <IsAotCompatible>true</IsAotCompatible>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NeutralLanguage>en</NeutralLanguage>
     <Description>
       Is a SDL2 for c#
@@ -57,10 +59,6 @@
     <Compile Remove="VulkanCore\**" />
     <EmbeddedResource Remove="VulkanCore\**" />
     <None Remove="VulkanCore\**" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <PackageReference Include="protobuf-net" Version="3.2.30" />
   </ItemGroup>
 
 </Project>

--- a/SDL-Sharp/SDL/SDL.Loader.cs
+++ b/SDL-Sharp/SDL/SDL.Loader.cs
@@ -33,7 +33,7 @@ public static partial class SDL
 
         if (_handle == IntPtr.Zero)
         {
-            foreach (var path in GetSearchPaths(assembly, libraryName))
+            foreach (var path in GetSearchPaths(libraryName))
             {
                 if (path != null && NativeLibrary.TryLoad(path, out _handle))
                 {
@@ -45,7 +45,7 @@ public static partial class SDL
         return _handle;
     }
 
-    private static IEnumerable<string> GetSearchPaths(Assembly assembly, string libraryName)
+    private static IEnumerable<string> GetSearchPaths(string libraryName)
     {
         string libName = GetNativeLibraryName(libraryName);
 

--- a/SDL-Sharp/SDL/SDL.Loader.cs
+++ b/SDL-Sharp/SDL/SDL.Loader.cs
@@ -51,7 +51,7 @@ public static partial class SDL
 
         // Try loading from runtimes/<rid>/native/<lib-name>
         yield return Path.Combine(
-        Path.GetDirectoryName(assembly.Location),
+        AppContext.BaseDirectory,
         "runtimes",
         GetRuntimeIdentifier(),
         "native",

--- a/SDL-Sharp/SDL_image/IMG.cs
+++ b/SDL-Sharp/SDL_image/IMG.cs
@@ -71,10 +71,7 @@ public static unsafe partial class IMG
 	{
 		Version result;
 		IntPtr result_ptr = INTERNAL_IMG_Linked_Version();
-		result = (Version)Marshal.PtrToStructure(
-			result_ptr,
-			typeof(Version)
-		);
+		result = Marshal.PtrToStructure<Version>(result_ptr);
 		return result;
 	}
 

--- a/SDL-Sharp/SDL_mixer/MIX.cs
+++ b/SDL-Sharp/SDL_mixer/MIX.cs
@@ -116,10 +116,7 @@ public unsafe static partial class MIX
 	{
 		Version result;
 		IntPtr result_ptr = INTERNAL_MIX_Linked_Version();
-		result = (Version)Marshal.PtrToStructure(
-			result_ptr,
-			typeof(Version)
-		);
+		result = Marshal.PtrToStructure<Version>(result_ptr);
 		return result;
 	}
 

--- a/SDL-Sharp/SDL_ttf/TTF.cs
+++ b/SDL-Sharp/SDL_ttf/TTF.cs
@@ -87,10 +87,7 @@ public unsafe static partial class TTF
 	{
 		Version result;
 		IntPtr result_ptr = INTERNAL_TTF_LinkedVersion();
-		result = (Version)Marshal.PtrToStructure(
-			result_ptr,
-			typeof(Version)
-		);
+		result = Marshal.PtrToStructure<Version>(result_ptr);
 		return result;
 	}
 


### PR DESCRIPTION
- Use .NET8 and enable AOT compatibility for the main project.
- Move Utils into extensions project.
- Move `protobuf-net` dependency out of main project.
- Fix-up AOT incompatible API usage 

If this PR is accepted, I have a few other minor changes.