### PR TITLE
Expose the SDL DLL loading as a public static function

### DIFF
--- a/Exemples/SDL_EXTENSIONS/Code/Program.cs
+++ b/Exemples/SDL_EXTENSIONS/Code/Program.cs
@@ -5,6 +5,7 @@ using SDL_Sharp.Utility;
 using SDL_Sharp;
 using System;
 using SDL_EXTENSIONS.Utils;
+using SDL_Sharp.Loader;
 
 namespace SDL_PLUS_EXTENSIONS;
 class Program
@@ -39,7 +40,7 @@ class Program
         //test save data ;)
 
         WinUtils.SetDpiAwareness(WinHighDpiMode.SystemAware);
-        SDL.DefaultDllImport();
+        SdlLoader.LoadDefault();
 
         //Init SDL/Image/Mixer/Ttf
         SDL.Init(SdlInitFlags.Video);

--- a/Exemples/SDL_EXTENSIONS/Code/Program.cs
+++ b/Exemples/SDL_EXTENSIONS/Code/Program.cs
@@ -39,6 +39,7 @@ class Program
         //test save data ;)
 
         WinUtils.SetDpiAwareness(WinHighDpiMode.SystemAware);
+        SDL.DefaultDllImport();
 
         //Init SDL/Image/Mixer/Ttf
         SDL.Init(SdlInitFlags.Video);

--- a/Exemples/SDL_OPENGL/Program.cs
+++ b/Exemples/SDL_OPENGL/Program.cs
@@ -27,6 +27,7 @@ internal class Program
     static void Main()
     {
         WinUtils.SetDpiAwareness(WinHighDpiMode.SystemAware);
+        SDL.DefaultDllImport();
 
         SDL.Init(SdlInitFlags.Video);
         window = SDL.CreateWindow("teste", SDL.WINDOWPOS_CENTERED, SDL.WINDOWPOS_CENTERED, 800, 600, WindowFlags.OpenGL);

--- a/Exemples/SDL_OPENGL/Program.cs
+++ b/Exemples/SDL_OPENGL/Program.cs
@@ -1,4 +1,5 @@
 ﻿using SDL_Sharp;
+using SDL_Sharp.Loader;
 using SDL_Sharp.Utility;
 using Silk.NET.OpenGL.Legacy;
 
@@ -27,7 +28,7 @@ internal class Program
     static void Main()
     {
         WinUtils.SetDpiAwareness(WinHighDpiMode.SystemAware);
-        SDL.DefaultDllImport();
+        SdlLoader.LoadDefault();
 
         SDL.Init(SdlInitFlags.Video);
         window = SDL.CreateWindow("teste", SDL.WINDOWPOS_CENTERED, SDL.WINDOWPOS_CENTERED, 800, 600, WindowFlags.OpenGL);

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Note2: News are coming in this project, it has been updated again!!!!!
 # How to setup
 First install [SDL-Sharp](https://www.nuget.org/packages//SDL-Sharp/)  nuget in your .NET project
 
-Before using any SDL function, consider calling [`SDL.DefaultDllImport();`](SDL-Sharp/SDL/SDL.Loader.cs), this function will load the necessary DLLs for the project. Otherwise, you will have to load the DLLs manually.
+Before using any SDL function, consider calling [`SdlLoader.LoadDefault();`](SDL-Sharp/Loader/SdlLoader.cs), this function will load the necessary DLLs for the project. Otherwise, you will have to load the DLLs manually.
 
 ### Linux
 Just install the sdl using a package manager of your system that [SDL-Sharp](https://www.nuget.org/packages//SDL-Sharp/)  will already use the sdl binaries

--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ Note2: News are coming in this project, it has been updated again!!!!!
 # How to setup
 First install [SDL-Sharp](https://www.nuget.org/packages//SDL-Sharp/)  nuget in your .NET project
 
+Before using any SDL function, consider calling [`SDL.DefaultDllImport();`](SDL-Sharp/SDL/SDL.Loader.cs), this function will load the necessary DLLs for the project. Otherwise, you will have to load the DLLs manually.
+
 ### Linux
 Just install the sdl using a package manager of your system that [SDL-Sharp](https://www.nuget.org/packages//SDL-Sharp/)  will already use the sdl binaries
 

--- a/SDL-Sharp/Loader/SdlLoader.cs
+++ b/SDL-Sharp/Loader/SdlLoader.cs
@@ -5,17 +5,18 @@ using System.Reflection;
 using System.Runtime.InteropServices;
 using SDL_Sharp.Utility;
 
-namespace SDL_Sharp;
-public static partial class SDL
-{
-    private const string LibraryName = "SDL2";
+namespace SDL_Sharp.Loader;
 
+public static class SdlLoader
+{
     /// <summary>
-    /// Default DllImportResolver for the SDL library.
+    /// Default Dll Import Resolver for the SDL-Sharp library.
     /// Currently, supports Windows, Linux, and OSX. Only x64 and x86 architectures are supported for now.
+    /// 
+    /// Consider calling this method before using any SDL-Sharp functionality. Otherwise you can load them manually yourself.
     /// </summary>
     /// <exception cref="PlatformNotSupportedException">When the current platform is not supported</exception>
-    public static void DefaultDllImport()
+    public static void LoadDefault()
     {
         if (RuntimeInformation.ProcessArchitecture == Architecture.X64)
         {

--- a/SDL-Sharp/SDL/SDL.Loader.cs
+++ b/SDL-Sharp/SDL/SDL.Loader.cs
@@ -10,7 +10,12 @@ public static partial class SDL
 {
     private const string LibraryName = "SDL2";
 
-    static SDL()
+    /// <summary>
+    /// Default DllImportResolver for the SDL library.
+    /// Currently, supports Windows, Linux, and OSX. Only x64 and x86 architectures are supported for now.
+    /// </summary>
+    /// <exception cref="PlatformNotSupportedException">When the current platform is not supported</exception>
+    public static void DefaultDllImport()
     {
         if (RuntimeInformation.ProcessArchitecture == Architecture.X64)
         {
@@ -51,11 +56,11 @@ public static partial class SDL
 
         // Try loading from runtimes/<rid>/native/<lib-name>
         yield return Path.Combine(
-        AppContext.BaseDirectory,
-        "runtimes",
-        GetRuntimeIdentifier(),
-        "native",
-        libName);
+            AppContext.BaseDirectory,
+            "runtimes",
+            GetRuntimeIdentifier(),
+            "native",
+            libName);
 
         // Finally, just try the name of the library
         yield return libName;

--- a/SDL-Sharp/SDL/SDL.cs
+++ b/SDL-Sharp/SDL/SDL.cs
@@ -22,6 +22,8 @@ public enum SdlInitFlags : uint
 
 public static unsafe partial class SDL
 {
+    private const string LibraryName = "SDL2";
+
     [DllImport(LibraryName, EntryPoint = "SDL_Init", CallingConvention = CallingConvention.Cdecl)]
     public static extern int Init(SdlInitFlags flags);
 


### PR DESCRIPTION
This allows more flexibility to load SDL-Sharp on platforms not explicitly supported. It allows custom DLL loading to take place. It avoids putting non-optional logic into static constructors.

Question:
- The new public static method has been exposed on the SDL class. I'm not certain this fits with the overall API design?